### PR TITLE
Avoid unnecessary buffer copies when exporting replays.

### DIFF
--- a/PubgReplayManager/Form1.Designer.cs
+++ b/PubgReplayManager/Form1.Designer.cs
@@ -35,7 +35,7 @@
             this.dataGridView2 = new System.Windows.Forms.DataGridView();
             this.label2 = new System.Windows.Forms.Label();
             this.RefreshButton = new System.Windows.Forms.Button();
-            this.Export = new System.Windows.Forms.Button();
+            this.Export_Button = new System.Windows.Forms.Button();
             this.exportFileDialog = new System.Windows.Forms.SaveFileDialog();
             this.import = new System.Windows.Forms.Button();
             this.importFileDialog = new System.Windows.Forms.OpenFileDialog();
@@ -119,15 +119,15 @@
             this.RefreshButton.Text = "Refresh";
             this.RefreshButton.UseVisualStyleBackColor = true;
             // 
-            // Export
+            // Export_Button
             // 
-            this.Export.Location = new System.Drawing.Point(371, 377);
-            this.Export.Name = "Export";
-            this.Export.Size = new System.Drawing.Size(75, 23);
-            this.Export.TabIndex = 7;
-            this.Export.Text = "Export";
-            this.Export.UseVisualStyleBackColor = true;
-            this.Export.Click += new System.EventHandler(this.Export_Click);
+            this.Export_Button.Location = new System.Drawing.Point(371, 377);
+            this.Export_Button.Name = "Export_Button";
+            this.Export_Button.Size = new System.Drawing.Size(75, 23);
+            this.Export_Button.TabIndex = 7;
+            this.Export_Button.Text = "Export";
+            this.Export_Button.UseVisualStyleBackColor = true;
+            this.Export_Button.Click += new System.EventHandler(this.Export_Click);
             // 
             // exportFileDialog
             // 
@@ -159,7 +159,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(834, 509);
             this.Controls.Add(this.import);
-            this.Controls.Add(this.Export);
+            this.Controls.Add(this.Export_Button);
             this.Controls.Add(this.RefreshButton);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.dataGridView2);
@@ -186,7 +186,7 @@
         private System.Windows.Forms.DataGridView dataGridView2;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Button RefreshButton;
-        private System.Windows.Forms.Button Export;
+        private System.Windows.Forms.Button Export_Button;
         private System.Windows.Forms.SaveFileDialog exportFileDialog;
         private System.Windows.Forms.Button import;
         private System.Windows.Forms.OpenFileDialog importFileDialog;

--- a/PubgReplayManager/Form1.cs
+++ b/PubgReplayManager/Form1.cs
@@ -22,19 +22,28 @@
             // On first open, set these settings to their defaults
             if (string.IsNullOrEmpty(Settings.Default.ReplaysFolder))
             {
-                Settings.Default.ReplaysFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\TslGame\\Saved\\Demos\\";
+                Settings.Default.ReplaysFolder =
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) +
+                    "\\TslGame\\Saved\\Demos\\";
             }
+
             if (string.IsNullOrEmpty(Settings.Default.BackupsFolder))
             {
-                Settings.Default.BackupsFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\PubgReplayManager\\";
+                Settings.Default.BackupsFolder =
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\PubgReplayManager\\";
             }
+
             // Create the backup folder if it doesn't exist
             Directory.CreateDirectory(Settings.Default.BackupsFolder);
             // Check for the existence of the ReplaysFolder
             if (!Directory.Exists(Settings.Default.ReplaysFolder))
             {
                 // If ReplaysFolder does not exist, have the user search for a new one, or close
-                if (MessageBox.Show(@"PUBG replays folder does not exist in default location, would you like to manually find the folder?", @"Replay Folder missing", MessageBoxButtons.YesNo) == DialogResult.Yes)
+                if (
+                    MessageBox.Show(@"PUBG replays folder does not exist in default location, would you like to manually find the folder?",
+                                    @"Replay Folder missing",
+                                    MessageBoxButtons.YesNo) ==
+                    DialogResult.Yes)
                 {
                     var replayBrowser = new FolderBrowserDialog();
                     if (replayBrowser.ShowDialog() == DialogResult.OK)
@@ -66,7 +75,12 @@
             dataGridView2.DataSource = Replay.BackupReplays;
             dataGridView2.CellMouseUp += dataGridView_CellValueChanged;
 
-            dataGridView1.Columns.Add(new DataGridViewCheckBoxColumn {HeaderText = @"Locked", DataPropertyName = "locked", Width = 50});
+            dataGridView1.Columns.Add(new DataGridViewCheckBoxColumn
+            {
+                HeaderText = @"Locked",
+                DataPropertyName = "locked",
+                Width = 50
+            });
 
             dataGridView1.Columns.Add("Time", "Time");
             dataGridView1.Columns["Time"].DataPropertyName = "timestamp";
@@ -85,10 +99,20 @@
             dataGridView1.Columns["Mode"].DataPropertyName = "mode";
             dataGridView1.Columns["Mode"].Width = 50;
 
-            dataGridView1.Columns.Add(new DataGridViewCheckBoxColumn {HeaderText = @"FPP", DataPropertyName = "fpp", Width = 50});
+            dataGridView1.Columns.Add(new DataGridViewCheckBoxColumn
+            {
+                HeaderText = @"FPP",
+                DataPropertyName = "fpp",
+                Width = 50
+            });
 
             // Hidden column containing folder location
-            dataGridView1.Columns.Add(new DataGridViewCheckBoxColumn {Name = "dir", DataPropertyName = "dir", Visible = false});
+            dataGridView1.Columns.Add(new DataGridViewCheckBoxColumn
+            {
+                Name = "dir",
+                DataPropertyName = "dir",
+                Visible = false
+            });
 
             foreach (DataGridViewColumn column in dataGridView1.Columns)
             {
@@ -134,7 +158,11 @@
                 string dest = Settings.Default.BackupsFolder + name;
                 if (Directory.Exists(dest))
                 {
-                    MessageBox.Show(@"The backup directory for this replay already exists, have you backed this up before?\nLocation: " + dest, @"Directory Exists", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(@"The backup directory for this replay already exists, have you backed this up before?\nLocation: " +
+                                    dest,
+                                    @"Directory Exists",
+                                    MessageBoxButtons.OK,
+                                    MessageBoxIcon.Error);
                 }
                 else
                 {
@@ -147,10 +175,15 @@
                     }
                     catch (IOException)
                     {
-                        MessageBox.Show(@"Unable to backup the file, if the problem persists try closing PUBG or running this program as Administrator.", @"Unable to move", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox
+                            .Show(@"Unable to backup the file, if the problem persists try closing PUBG or running this program as Administrator.",
+                                  @"Unable to move",
+                                  MessageBoxButtons.OK,
+                                  MessageBoxIcon.Error);
                     }
                 }
             }
+
             RefreshDisplays();
         }
 
@@ -163,7 +196,11 @@
                 string source = Settings.Default.BackupsFolder + name;
                 if (Directory.Exists(dest))
                 {
-                    MessageBox.Show(@"The restore directory for this replay already exists, have you restored this before?\nLocation: " + dest, @"Directory Exists", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show(@"The restore directory for this replay already exists, have you restored this before?\nLocation: " +
+                                    dest,
+                                    @"Directory Exists",
+                                    MessageBoxButtons.OK,
+                                    MessageBoxIcon.Error);
                 }
                 else
                 {
@@ -176,10 +213,15 @@
                     }
                     catch (IOException)
                     {
-                        MessageBox.Show(@"Unable to backup the file, if the problem persists try closing PUBG or running this program as Administrator.", @"Unable to move", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox
+                            .Show(@"Unable to backup the file, if the problem persists try closing PUBG or running this program as Administrator.",
+                                  @"Unable to move",
+                                  MessageBoxButtons.OK,
+                                  MessageBoxIcon.Error);
                     }
                 }
             }
+
             RefreshDisplays();
         }
 
@@ -194,7 +236,10 @@
             if (grid.Columns[e.ColumnIndex].HeaderText == "Locked")
             {
                 object dir = grid.Rows[e.RowIndex].Cells["dir"].Value;
-                string file = (grid.Name == "dataGridView1" ? Settings.Default.ReplaysFolder : Settings.Default.BackupsFolder) + dir + ReplayInfoFile;
+                string file =
+                    (grid.Name == "dataGridView1" ? Settings.Default.ReplaysFolder : Settings.Default.BackupsFolder) +
+                    dir +
+                    ReplayInfoFile;
                 string text = File.ReadAllText(file);
                 if (text.Contains(keepTrue))
                 {
@@ -272,7 +317,7 @@
                 {
                     // A HashSet containing names of all playlists in the archive
                     var replays = new HashSet<string>();
-                    
+
                     foreach (ZipArchiveEntry entry in archive.Entries)
                     {
                         // Get the replay name of the entry
@@ -308,7 +353,9 @@
                             // Create the folders neccessary if they don't exist
                             if (!Directory.Exists(entryPath))
                             {
-                                Directory.CreateDirectory(Path.GetDirectoryName(entryPath) ?? throw new InvalidOperationException()); // Exception should be impossible
+                                Directory.CreateDirectory(Path.GetDirectoryName(entryPath) ??
+                                                          throw new
+                                                              InvalidOperationException()); // Exception should be impossible
                             }
 
                             // Open the file and write the replay file
@@ -326,11 +373,45 @@
             LoadReplays();
         }
 
+
+        private void Export(string destFile)
+        {
+            // Export all selected backed up replays. TODO: Support both loaded and backed up replays
+            IEnumerable<Replay> selected = dataGridView2
+                                           .SelectedRows.Cast<DataGridViewRow>()
+                                           .Select(row => row.Cells["dir"].Value.ToString())
+                                           .Select(name => Replay.BackupReplays.First(x => x.dir == name))
+                                           .ToList();
+
+            // Create a MemoryStream that holds an in-memory zip archive
+            using (var fileStream = new FileStream(destFile, FileMode.Create))
+            {
+                // Create a ZipArchive that writes to the MemoryStream
+                using (var archive = new ZipArchive(fileStream, ZipArchiveMode.Create, true))
+                {
+                    // Get the name of all the replays that should be saved
+                    foreach (string replay in selected.Select(r => r.dir))
+                    {
+                        // Get the full path of the replay
+                        string source = Path.Combine(Settings.Default.BackupsFolder, replay);
+
+                        // Get all the files in all subdirectories
+                        string[] allFiles = Directory.GetFiles(source, "*", SearchOption.AllDirectories);
+
+                        // Loop through each file contained in each replay
+                        foreach (string file in allFiles)
+                        {
+                            // Create an entry in the archive for the file. The names are relative to the root, so we remove everything from the path that is higher or equal to the root
+                            archive.CreateEntryFromFile(file, file.Remove(0, Settings.Default.BackupsFolder.Length));
+                        }
+                    }
+                }
+            }
+        }
+
+
         private void Export_Click(object sender, EventArgs e)
         {
-            // Export all backed up replays. TODO: Support both loaded and backed up replays
-            IEnumerable<Replay> selected = dataGridView2.SelectedRows.Cast<DataGridViewRow>().Select(row => row.Cells["dir"].Value.ToString()).Select(name => Replay.BackupReplays.First(x => x.dir == name)).ToList();
-
             // Only proceed if a file has been successfully selected
             DialogResult result = exportFileDialog.ShowDialog();
             if (result != DialogResult.OK)
@@ -342,43 +423,8 @@
             string zipFileName = exportFileDialog.FileName;
 
             // Run the archiving in a seperate non-blocking thread.
-            new Thread(() =>
-                       {
-                           // Create a MemoryStream that holds an in-memory zip archive
-                           using (var memoryStream = new MemoryStream())
-                           {
-                               // Create a ZipArchive that writes to the MemoryStream
-                               using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, true))
-                               {
-                                   // Get the name of all the replays that should be saved
-                                   foreach (string replay in selected.Select(r => r.dir))
-                                   {
-                                       // Get the full path of the replay
-                                       string source = Path.Combine(Settings.Default.BackupsFolder, replay);
-
-                                       // Get all the files in all subdirectories
-                                       string[] allFiles = Directory.GetFiles(source, "*", SearchOption.AllDirectories);
-
-                                       // Loop through each file contained in each replay
-                                       foreach (string file in allFiles)
-                                       {
-                                           // Create an entry in the archive for the file. The names are relative to the root, so we remove everything from the path that is higher or equal to the root
-                                           archive.CreateEntryFromFile(file, file.Remove(0, Settings.Default.BackupsFolder.Length));
-                                       }
-                                   }
-                               }
-
-                               // Open the output zip file
-                               using (var fileStream = new FileStream(zipFileName, FileMode.Create))
-                               {
-                                   // Revert to the beginning of the zip stream
-                                   memoryStream.Seek(0, SeekOrigin.Begin);
-
-                                   // Copy the zip archive to the file on disk
-                                   memoryStream.CopyTo(fileStream);
-                               }
-                           }
-                       }).Start();
+            new Thread(() => { Export(zipFileName); }).Start();
         }
     }
 }
+cl

--- a/PubgReplayManager/Form1.cs
+++ b/PubgReplayManager/Form1.cs
@@ -315,7 +315,7 @@
                 // Read a zip archive with the zip stream
                 using (var archive = new ZipArchive(zipStream, ZipArchiveMode.Read))
                 {
-                    // A HashSet containing names of all playlists in the archive
+                    // A HashSet containing names of all replays in the archive
                     var replays = new HashSet<string>();
 
                     foreach (ZipArchiveEntry entry in archive.Entries)
@@ -427,4 +427,3 @@
         }
     }
 }
-cl


### PR DESCRIPTION
Instead of writing to a MemoryBuffer that is then copied to a FileStream we are now writing directly to the FileStream.